### PR TITLE
use now() instead of 'now'

### DIFF
--- a/lib/que/sql.rb
+++ b/lib/que/sql.rb
@@ -60,7 +60,7 @@ module Que
       INSERT INTO que_jobs
       (queue, priority, run_at, job_class, args)
       VALUES
-      (coalesce($1, '')::text, coalesce($2, 100)::smallint, coalesce($3, 'now')::timestamptz, $4::text, coalesce($5, '[]')::json)
+      (coalesce($1, '')::text, coalesce($2, 100)::smallint, coalesce($3, now())::timestamptz, $4::text, coalesce($5, '[]')::json)
       RETURNING *
     }.freeze,
 


### PR DESCRIPTION
The argument `'now'` is evaluated when the statement is prepared, not when
it is executed. So the timestamp in the `insert_job` query will be stale
after the first execution.

Switching it to `now()` ensures that it is always evaluated when the query
is executed.

See https://github.com/bgentry/que-go/issues/1 for more details.

Not sure if you think this needs a test or not, but you'd probably have a better idea of how you want that to look if so.

P.S. I made a golang port of Que :) https://github.com/bgentry/que-go