### PR TITLE
fix que:work task to actually wait for running jobs to finish

### DIFF
--- a/lib/que/rake_tasks.rb
+++ b/lib/que/rake_tasks.rb
@@ -19,6 +19,7 @@ namespace :que do
 
     at_exit do
       $stdout.puts "Finishing Que's current jobs before exiting..."
+      Que.worker_count = 0
       Que.mode = :off
       $stdout.puts "Que's jobs finished, exiting..."
     end


### PR DESCRIPTION
It turned out that after commit 3981bd450ad8d6ecc2672cafd8fa460554971244, `que:work` rake task actually stopped waiting for jobs to finish despite claiming to do so. I made a little fix setting `Que.worker_count` to 0, however I don't understand why setting mode to :off doesn't do that.