### PR TITLE
Added support for `jsonb` datatype

### DIFF
--- a/docs/inspecting_the_queue.md
+++ b/docs/inspecting_the_queue.md
@@ -79,6 +79,10 @@ If you want to use ActiveRecord's features when querying, you can define your ow
 
 Then you can query just as you would with any other model. Since the jobs table has a composite primary key, however, you probably won't be able to update or destroy jobs this way, though.
 
+Additionally, if you're running PG >=9.4 and have Que's DB version migrated to >=4, you can query within the 'args' column easily:
+
+    QueJob.where(job_class: 'SomeJobClass').where('args @> \'[1]\'')
+
 If you're using Sequel, you can use the same technique:
 
     class QueJob < Sequel::Model

--- a/lib/generators/que/templates/add_que.rb
+++ b/lib/generators/que/templates/add_que.rb
@@ -1,7 +1,7 @@
 class AddQue < ActiveRecord::Migration
   def self.up
     # The current version as of this migration's creation.
-    Que.migrate! :version => 3
+    Que.migrate! :version => 4
   end
 
   def self.down

--- a/lib/que.rb
+++ b/lib/que.rb
@@ -40,6 +40,10 @@ module Que
       @adapter || raise("Que connection not established!")
     end
 
+    def supports_jsonb?
+      execute("SELECT data_type FROM information_schema.columns WHERE table_name = 'que_jobs' AND column_name='args'")[0]['data_type'] == 'jsonb'
+    end
+
     def execute(*args)
       adapter.execute(*args)
     end

--- a/lib/que/adapters/base.rb
+++ b/lib/que/adapters/base.rb
@@ -110,7 +110,9 @@ module Que
       CAST_PROCS[1184] = Time.method(:parse)
 
       # JSON.
-      CAST_PROCS[114] = JSON_MODULE.method(:load)
+      CAST_PROCS[114]  = JSON_MODULE.method(:load)
+      # JSONB.
+      CAST_PROCS[3802] = JSON_MODULE.method(:load)
 
       # Boolean:
       CAST_PROCS[16] = 't'.method(:==)

--- a/lib/que/migrations.rb
+++ b/lib/que/migrations.rb
@@ -3,7 +3,7 @@ module Que
     # In order to ship a schema change, add the relevant up and down sql files
     # to the migrations directory, and bump the version both here and in the
     # add_que generator template.
-    CURRENT_VERSION = 3
+    CURRENT_VERSION = 4
 
     class << self
       def migrate!(options = {:version => CURRENT_VERSION})

--- a/lib/que/migrations/4/down.sql
+++ b/lib/que/migrations/4/down.sql
@@ -1,0 +1,7 @@
+DO $$
+  BEGIN
+    ALTER TABLE que_jobs ALTER COLUMN args DROP DEFAULT;
+    ALTER TABLE que_jobs ALTER COLUMN args TYPE json USING args::json;
+    ALTER TABLE que_jobs ALTER COLUMN args SET DEFAULT '[]'::json;
+  END;
+$$;

--- a/lib/que/migrations/4/up.sql
+++ b/lib/que/migrations/4/up.sql
@@ -1,0 +1,11 @@
+DO $$
+  BEGIN
+    IF 90400 >= (SELECT setting::integer FROM pg_settings WHERE name = 'server_version_num') THEN
+      ALTER TABLE que_jobs ALTER COLUMN args DROP DEFAULT;
+      ALTER TABLE que_jobs ALTER COLUMN args TYPE jsonb USING args::jsonb;
+      ALTER TABLE que_jobs ALTER COLUMN args SET DEFAULT '[]'::jsonb;
+    ELSE
+      RAISE NOTICE 'Using `json` datatype as your version of PG is < 9.4';
+    END IF;
+  END;
+$$;

--- a/lib/que/sql.rb
+++ b/lib/que/sql.rb
@@ -60,7 +60,7 @@ module Que
       INSERT INTO que_jobs
       (queue, priority, run_at, job_class, args)
       VALUES
-      (coalesce($1, '')::text, coalesce($2, 100)::smallint, coalesce($3, now())::timestamptz, $4::text, coalesce($5, '[]')::json)
+      (coalesce($1, '')::text, coalesce($2, 100)::smallint, coalesce($3, now())::timestamptz, $4::text, coalesce($5, '[]')::#{Que.supports_jsonb? ? 'jsonb' : 'json'})
       RETURNING *
     }.freeze,
 


### PR DESCRIPTION
Now that 9.4 is released and the docs suggest defaulting to `jsonb` ([link](http://www.postgresql.org/docs/9.4/static/datatype-json.html)), I've added an additional migration to conditionally alter `que_jobs`' `args` column to `jsonb`.

If the version of PG doesn't support `jsonb`, the migration is essentially a noop.

When building the `:insert_job` SQL statement and while casting return types, the type of `args` is determined and set, providing backwards compatibility.

Additionally I provided a quick example for how one might query against the values contained within `args`, assuming `jsonb` is used.