### PR TITLE
Update `error_handling` documentation.

### DIFF
--- a/docs/error_handling.md
+++ b/docs/error_handling.md
@@ -20,6 +20,6 @@ Unlike DelayedJob, however, there is currently no maximum number of failures aft
 
 If you're using an error notification system (highly recommended, of course), you can hook Que into it by setting a callable as the error handler:
 
-    Que.error_handler = proc do |error|
-      # Do whatever you want with the error object.
+    Que.error_handler = proc do |error, job|
+      # Do whatever you want with the error or job object.
     end


### PR DESCRIPTION
It seemed strange that the error handler wasn't being given the job that had failed, upon closer inspection of the code I noticed that the job is in fact passed to the handler.  This PR just updates the documentation to express that fact.