### PR TITLE
Allow a user to configure workers for multiple queues.

### DIFF
--- a/spec/unit/worker_spec.rb
+++ b/spec/unit/worker_spec.rb
@@ -162,4 +162,10 @@ describe Que::Worker do
       @worker.wait_until_stopped
     end
   end
+
+  it 'configures the desired number of workers' do
+    expect {
+      Que::Worker.worker_count = 2
+    }.to change { Que::Worker.workers.count }.to(2)
+  end
 end

--- a/spec/unit/worker_spec.rb
+++ b/spec/unit/worker_spec.rb
@@ -167,5 +167,16 @@ describe Que::Worker do
     expect {
       Que::Worker.worker_count = 2
     }.to change { Que::Worker.workers.count }.to(2)
+
+    Que::Worker.worker_count = 0 # cleanup
+  end
+
+  it 'accepts multiple queues and configures that number of workers per queue' do
+    stub_const 'ENV', 'QUE_QUEUE' => 'custom,other'
+    expect {
+      Que::Worker.worker_count = 2
+    }.to change { Que::Worker.workers.count }.to(4)
+
+    Que::Worker.worker_count = 0 # cleanup
   end
 end


### PR DESCRIPTION
Currently, que supports running jobs from only one queue as named per `ENV['QUE_QUEUE']`, as per #71 Rails default implementation of `ActiveJob` uses two queues, `default` and `mailers`. 

This is (hopefully) the start of a conversation on how to better support Rails users who might (like me) naively assume `config.active_job.queue_adapter = :que` and `rake que:work` is enough to get everything working.

I know I could specify multiple `rake que:work` jobs to get the same effect, but I'd like to do this on 1 dyno on Heroku and this is a naive attempt at making that work.