### PR TITLE
Add flexible failure handling

### DIFF
--- a/lib/que/migrations.rb
+++ b/lib/que/migrations.rb
@@ -3,7 +3,7 @@ module Que
     # In order to ship a schema change, add the relevant up and down sql files
     # to the migrations directory, and bump the version both here and in the
     # add_que generator template.
-    CURRENT_VERSION = 3
+    CURRENT_VERSION = 4
 
     class << self
       def migrate!(options = {:version => CURRENT_VERSION})

--- a/lib/que/migrations/4/down.sql
+++ b/lib/que/migrations/4/down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE que_jobs
+  DROP COLUMN retryable,
+  DROP COLUMN failed_at;

--- a/lib/que/migrations/4/up.sql
+++ b/lib/que/migrations/4/up.sql
@@ -1,0 +1,4 @@
+ALTER TABLE que_jobs
+  ADD COLUMN retryable BOOL DEFAULT TRUE,
+  ADD COLUMN failed_at TIMESTAMPTZ;
+UPDATE que_jobs SET retryable = true;

--- a/spec/unit/states_spec.rb
+++ b/spec/unit/states_spec.rb
@@ -27,7 +27,7 @@ describe Que, '.worker_states' do
     t.join
 
     state = states.first
-    state.keys.should == %w(priority run_at job_id job_class args error_count last_error queue pg_backend_pid pg_state pg_state_changed_at pg_last_query pg_last_query_started_at pg_transaction_started_at pg_waiting_on_lock)
+    state.keys.should == %w(priority run_at job_id job_class args error_count last_error queue retryable failed_at pg_backend_pid pg_state pg_state_changed_at pg_last_query pg_last_query_started_at pg_transaction_started_at pg_waiting_on_lock)
 
     state[:priority].should == 2
     state[:run_at].should be_within(3).of Time.now


### PR DESCRIPTION
Hi Chris,

We've tried to come up with some modest changes that would allow us to implement the different kinds of failure behaviours that we currently use at GoCardless. This pull request contains everything that is necessary to get us going, and we've actually got a Job running on this in production right now.

We've written a gem called `que-retry` that makes use of these changes.  We're hoping to open source it soon, but it's not quite ready.  Looking at it might provide better context for our changes, so let us know if you'd like to take a look.

The current changes are:
- The failure handling code from the work loop has been extracted into a method of it's own.
- A `retryable` field has been introduced to stop "failed" jobs from being re-run constantly.
- A `retryable` argument has been added to `Job`.
- The new migration sets `retryable` to true for all existing jobs.  This ensures users with existing jobs will be unaffected.
- The `lock_job` query has been updated to only select jobs that are `retryable`.
- A `failed_at` field has been added for introspection/diagnostic purposes.
- The `freeze` on `Que::SQL` has been removed, because we needed to introduce more queries in our `que-retry` gem.

The last point is one we've been unsure about, it could be avoided by including one of our queries in `Que` itself, but by default it wouldn't be used by `Que`.  It would be great to hear how you feel about this, and we'd be happy to show you `que-retry`.  It's not quite finished, but it's pretty close, and will be open-sourced.

Another change that starts to make sense when you look at `que-retry` is the possibility of passing instances of Jobs to the handlers, rather than hashes.  It would end up being a bit cleaner.

One last thing to note, is that we have been running our branch in `queue-shootout` against your master to make sure we've not had a detrimental impact on performance, so far it's a close match and seems like we've had literally no impact.