### PR TITLE
Document Que's `lock_job` mechanism

### DIFF
--- a/lib/que/sql.rb
+++ b/lib/que/sql.rb
@@ -19,8 +19,7 @@ module Que
     # table as it continues to iterate through `que_jobs` looking for a lock.
     # The jobs table has a sort on (priority, run_at, job_id) which allows it
     # to walk the jobs table in a stable way. As noted above, the recursion
-    # examines one job at at at time so that it only ever acquires a single
-    # lock.
+    # examines one job at a time so that it only ever acquires a single lock.
     #
     # The recursion has two possible end conditions:
     #

--- a/lib/que/sql.rb
+++ b/lib/que/sql.rb
@@ -1,5 +1,40 @@
 module Que
   SQL = {
+    # Locks a job using a Postgres recursive CTE [1].
+    #
+    # As noted by the Postgres documentation, it may be slightly easier to
+    # think about this expression as iteration rather than recursion, despite
+    # the `RECURSION` nomenclature defined by the SQL standards committee.
+    # Recursion is used here so that jobs in the table can be iterated
+    # one-by-one until a lock can be acquired, where a non-recursive `SELECT`
+    # would have the undesirable side-effect of locking multiple jobs at once.
+    # i.e. Consider that the following would have the worker lock *all*
+    # unlocked jobs:
+    #
+    #   SELECT (j).*, pg_try_advisory_lock((j).job_id) AS locked
+    #   FROM que_jobs AS j;
+    #
+    # The CTE will initially produce an "anchor" from the non-recursive term
+    # (i.e. before the `UNION`), and then use it as the contents of the working
+    # table as it continues to iterate through `que_jobs` looking for a lock.
+    # The jobs table has a sort on (priority, run_at, job_id) which allows it
+    # to walk the jobs table in a stable way. As noted above, the recursion
+    # examines one job at at at time so that it only ever acquires a single
+    # lock.
+    #
+    # The recursion has two possible end conditions:
+    #
+    # 1. If a lock *can* be acquired, it bubbles up to the top-level `SELECT`
+    #    outside of the `job` CTE which stops recursion because it is
+    #    constrained with a `LIMIT` of 1.
+    #
+    # 2. If a lock *cannot* be acquired, the recursive term of the expression
+    #    (i.e. what's after the `UNION`) will return an empty result set
+    #    because there are no more candidates left that could possibly be
+    #    locked. This empty result automatically ends recursion.
+    #
+    # [1] http://www.postgresql.org/docs/devel/static/queries-with.html
+    #
     # Thanks to RhodiumToad in #postgresql for help with the job lock CTE.
     :lock_job => %{
       WITH RECURSIVE job AS (


### PR DESCRIPTION
I had a bit of a hard time understanding exactly how this locking function worked when I first examined it. This pull adds a little bit of a explanatory documentation in an attempt to make it a little easier to digest.

This may be redundant to the SQL elite among us, but could potentially be helpful to people who are more casually browsing the repository.

/cc @fdr Hey! Would you mind proof-reading this one for accuracy?