### PR TITLE
Command Line Interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ### 0.11.0 (Unreleased)
 
+*   A command-line program has been added that can be used to work jobs in a more flexible manner than the previous rake task. Run `que -h` for more information.
+
+*   The `rake que:work` rake task that was specific to Rails has been removed in favor of the CLI, and the various QUE_* environment variables no longer have any effect.
+
+*   The worker pool will no longer start automatically in the same process when running the rails server - this behavior was too prone to breakage. If you'd like to recreate the old behavior, you can manually set `Que.mode = :async` in your app whenever conditions are appropriate (classes have loaded, a database connection has been established, and the process will not be forking).
+
 *   Add a Que.disable_prepared_transactions= configuration option, to make it easier to use tools like pgbouncer. (#110)
 
 ### 0.10.0 (2015-03-18)

--- a/bin/que
+++ b/bin/que
@@ -74,15 +74,13 @@ Que.mode          = :async
 stop = false
 %w(INT TERM).each { |signal| trap(signal) { stop = true } }
 
-at_exit do
-  $stdout.puts
-  $stdout.puts "Finishing Que's current jobs before exiting..."
-  Que.worker_count = 0
-  Que.mode = :off
-  $stdout.puts "Que's jobs finished, exiting..."
-end
-
 loop do
   sleep 0.01
   break if stop
 end
+
+$stdout.puts
+$stdout.puts "Finishing Que's current jobs before exiting..."
+Que.worker_count = 0
+Que.mode = :off
+$stdout.puts "Que's jobs finished, exiting..."

--- a/bin/que
+++ b/bin/que
@@ -10,7 +10,7 @@ options.log_level = 'info'
 options.wake_interval = 0.1
 
 OptionParser.new do |opts|
-  opts.banner = 'usage: que [options] (filename) ...'
+  opts.banner = 'usage: que [options] file/to/require ...'
 
   opts.on('-w', '--worker-count [COUNT]', Integer, "Set number of workers in process (default: 4)") do |worker_count|
     options.worker_count = worker_count
@@ -28,16 +28,26 @@ OptionParser.new do |opts|
     options.queue_name = queue_name
   end
 
-  opts.on('-v', '--version', "Print Que's version and exit") do
+  opts.on('-v', '--version', "Show Que version") do
     $stdout.puts "Que version #{Version}"
     exit 0
   end
 
-  opts.on('-h', '--help', "Show help text and exit") do
+  opts.on('-h', '--help', "Show help text") do
     $stdout.puts opts
     exit 0
   end
 end.parse!(ARGV)
+
+if ARGV.length.zero?
+  $stdout.puts <<-OUTPUT
+You didn't include any Ruby files to require!
+Que needs to be able to load your application before it can process jobs.
+(Hint: If you're using Rails, try `que config/environment.rb`)
+(Or use `que -h` for a list of options)
+OUTPUT
+exit 1
+end
 
 ARGV.each do |file|
   begin
@@ -70,6 +80,7 @@ stop = false
 %w(INT TERM).each { |signal| trap(signal) { stop = true } }
 
 at_exit do
+  $stdout.puts
   $stdout.puts "Finishing Que's current jobs before exiting..."
   Que.worker_count = 0
   Que.mode = :off

--- a/bin/que
+++ b/bin/que
@@ -5,9 +5,6 @@ require 'ostruct'
 require 'logger'
 
 options = OpenStruct.new
-options.worker_count = 4
-options.log_level = 'info'
-options.wake_interval = 0.1
 
 OptionParser.new do |opts|
   opts.banner = 'usage: que [options] file/to/require ...'
@@ -59,16 +56,18 @@ end
 
 Que.logger ||= Logger.new(STDOUT)
 
+log_level = options.log_level || 'info'
+
 begin
-  Que.logger.level = Logger.const_get(options.log_level.upcase)
+  Que.logger.level = Logger.const_get(log_level.upcase)
 rescue NameError
-  $stdout.puts "Bad logging level: #{options.log_level}"
+  $stdout.puts "Bad logging level: #{log_level}"
   exit 1
 end
 
-Que.queue_name    = options.queue_name
-Que.worker_count  = options.worker_count
-Que.wake_interval = options.wake_interval
+Que.queue_name    = options.queue_name    || Que.queue_name    || nil
+Que.worker_count  = options.worker_count  || Que.worker_count  || 4
+Que.wake_interval = options.wake_interval || Que.wake_interval || 0.1
 Que.mode          = :async
 
 stop = false

--- a/bin/que
+++ b/bin/que
@@ -16,12 +16,16 @@ OptionParser.new do |opts|
     options.worker_count = worker_count
   end
 
+  opts.on('-i', '--wake-interval [INTERVAL]', Float, "Set maximum interval between polls of the job queue (in seconds) (default: 0.1)") do |wake_interval|
+    options.wake_interval = wake_interval
+  end
+
   opts.on('-l', '--log-level [LEVEL]', String, "Set level of Que's logger (debug, info, warn, error, fatal) (default: info)") do |log_level|
     options.log_level = log_level
   end
 
-  opts.on('-i', '--wake-interval [INTERVAL]', Float, "Set maximum interval between polls of the job queue (in seconds) (default: 0.1)") do |wake_interval|
-    options.wake_interval = wake_interval
+  opts.on('-q', '--queue-name [NAME]', String, "Set the name of the queue to work jobs from (default: the default queue)") do |queue_name|
+    options.queue_name = queue_name
   end
 
   opts.on('-v', '--version', "Print Que's version and exit") do
@@ -57,6 +61,7 @@ rescue NameError
   exit 1
 end
 
+Que.queue_name    = options.queue_name
 Que.worker_count  = options.worker_count
 Que.wake_interval = options.wake_interval
 Que.mode          = :async

--- a/bin/que
+++ b/bin/que
@@ -1,0 +1,77 @@
+#!/usr/bin/env ruby
+
+require 'optparse'
+require 'ostruct'
+require 'logger'
+
+options = OpenStruct.new
+options.worker_count = 4
+options.log_level = 'info'
+options.wake_interval = 0.1
+
+OptionParser.new do |opts|
+  opts.banner = 'usage: que [options] (filename) ...'
+
+  opts.on('-w', '--worker-count [COUNT]', Integer, "Set number of workers in process (default: 4)") do |worker_count|
+    options.worker_count = worker_count
+  end
+
+  opts.on('-l', '--log-level [LEVEL]', String, "Set level of Que's logger (debug, info, warn, error, fatal) (default: info)") do |log_level|
+    options.log_level = log_level
+  end
+
+  opts.on('-i', '--wake-interval [INTERVAL]', Float, "Set maximum interval between polls of the job queue (in seconds) (default: 0.1)") do |wake_interval|
+    options.wake_interval = wake_interval
+  end
+
+  opts.on('-v', '--version', "Print Que's version and exit") do
+    $stdout.puts "Que version #{Version}"
+    exit 0
+  end
+
+  opts.on('-h', '--help', "Show help text and exit") do
+    $stdout.puts opts
+    exit 0
+  end
+end.parse!(ARGV)
+
+ARGV.each do |file|
+  begin
+    # Need to add '.' to load path for relative requires
+    $LOAD_PATH << '.'
+    require file
+  rescue LoadError
+    $stdout.puts "Could not load file '#{file}'"
+  ensure
+    # Clean up load path
+    $LOAD_PATH.pop
+  end
+end
+
+Que.logger ||= Logger.new(STDOUT)
+
+begin
+  Que.logger.level = Logger.const_get(options.log_level.upcase)
+rescue NameError
+  $stdout.puts "Bad logging level: #{options.log_level}"
+  exit 1
+end
+
+Que.worker_count  = options.worker_count
+Que.wake_interval = options.wake_interval
+Que.mode          = :async
+
+stop = false
+%w(INT TERM).each { |signal| trap(signal) { stop = true } }
+
+at_exit do
+  $stdout.puts "Finishing Que's current jobs before exiting..."
+  Que.worker_count = 0
+  Que.mode = :off
+  $stdout.puts "Que's jobs finished, exiting..."
+end
+
+loop do
+  sleep 0.01
+  break if stop
+end

--- a/bin/que
+++ b/bin/que
@@ -43,7 +43,7 @@ if ARGV.length.zero?
   $stdout.puts <<-OUTPUT
 You didn't include any Ruby files to require!
 Que needs to be able to load your application before it can process jobs.
-(Hint: If you're using Rails, try `que config/environment.rb`)
+(Hint: If you're using Rails, try `que ./config/environment.rb`)
 (Or use `que -h` for a list of options)
 OUTPUT
 exit 1
@@ -51,14 +51,9 @@ end
 
 ARGV.each do |file|
   begin
-    # Need to add '.' to load path for relative requires
-    $LOAD_PATH << '.'
     require file
   rescue LoadError
     $stdout.puts "Could not load file '#{file}'"
-  ensure
-    # Clean up load path
-    $LOAD_PATH.pop
   end
 end
 

--- a/lib/que.rb
+++ b/lib/que.rb
@@ -127,7 +127,7 @@ module Que
     end
 
     # Copy some of the Worker class' config methods here for convenience.
-    [:mode, :mode=, :worker_count, :worker_count=, :wake_interval, :wake_interval=, :wake!, :wake_all!].each do |meth|
+    [:mode, :mode=, :worker_count, :worker_count=, :wake_interval, :wake_interval=, :queue_name, :queue_name=, :wake!, :wake_all!].each do |meth|
       define_method(meth) { |*args| Worker.send(meth, *args) }
     end
   end

--- a/lib/que/railtie.rb
+++ b/lib/que/railtie.rb
@@ -9,21 +9,5 @@ module Que
     rake_tasks do
       load 'que/rake_tasks.rb'
     end
-
-    initializer 'que.setup' do
-      ActiveSupport.on_load :after_initialize do
-        # Only start up the worker pool if running as a server.
-        Que.mode ||= :async if defined? Rails::Server
-
-        at_exit do
-          if Que.mode == :async
-            $stdout.puts "Finishing Que's current jobs before exiting..."
-            Que.worker_count = 0
-            Que.mode = :off
-            $stdout.puts "Que's jobs finished, exiting..."
-          end
-        end
-      end
-    end
   end
 end

--- a/lib/que/rake_tasks.rb
+++ b/lib/que/rake_tasks.rb
@@ -1,40 +1,4 @@
 namespace :que do
-  desc "Process Que's jobs using a worker pool"
-  task :work => :environment do
-    if defined?(::Rails) && Rails.respond_to?(:application)
-      # ActiveSupport's dependency autoloading isn't threadsafe, and Que uses
-      # multiple threads, which means that eager loading is necessary. Rails
-      # explicitly prevents eager loading when the environment task is invoked,
-      # so we need to manually eager load the app here.
-      Rails.application.eager_load!
-    end
-
-    Que.logger.level  = Logger.const_get((ENV['QUE_LOG_LEVEL'] || 'INFO').upcase)
-    Que.worker_count  = (ENV['QUE_WORKER_COUNT'] || 4).to_i
-    Que.wake_interval = (ENV['QUE_WAKE_INTERVAL'] || 0.1).to_f
-    Que.mode          = :async
-
-    # When changing how signals are caught, be sure to test the behavior with
-    # the rake task in tasks/safe_shutdown.rb.
-
-    stop = false
-    %w( INT TERM ).each do |signal|
-      trap(signal) {stop = true}
-    end
-
-    at_exit do
-      $stdout.puts "Finishing Que's current jobs before exiting..."
-      Que.worker_count = 0
-      Que.mode = :off
-      $stdout.puts "Que's jobs finished, exiting..."
-    end
-
-    loop do
-      sleep 0.01
-      break if stop
-    end
-  end
-
   desc "Migrate Que's job table to the most recent version (creating it if it doesn't exist)"
   task :migrate => :environment do
     Que.migrate!

--- a/lib/que/worker.rb
+++ b/lib/que/worker.rb
@@ -119,6 +119,7 @@ module Que
 
     class << self
       attr_reader :mode, :wake_interval, :worker_count
+      attr_accessor :queue_name
 
       # In order to work in a forking webserver, we need to be able to accept
       # worker_count and wake_interval settings without actually instantiating
@@ -162,7 +163,7 @@ module Que
 
       def set_up_workers
         if worker_count > workers.count
-          workers.push(*(worker_count - workers.count).times.map{new(ENV['QUE_QUEUE'] || '')})
+          workers.push(*(worker_count - workers.count).times.map{new(queue_name || '')})
         elsif worker_count < workers.count
           workers.pop(workers.count - worker_count).each(&:stop).each(&:wait_until_stopped)
         end

--- a/que.gemspec
+++ b/que.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = `git ls-files`.split($/)
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  spec.executables   = ['que']
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 

--- a/spec/unit/pool_spec.rb
+++ b/spec/unit/pool_spec.rb
@@ -103,12 +103,12 @@ describe "Managing the Worker pool" do
         sleep_until { DB[:que_jobs].count == 0 }
       end
 
-      it "should work jobs in the queue defined by QUE_QUEUE" do
+      it "should work jobs in the queue defined by the Que.queue_name config option" do
         begin
           Que::Job.enqueue 1
           Que::Job.enqueue 2, :queue => 'my_queue'
 
-          ENV['QUE_QUEUE'] = 'my_queue'
+          Que.queue_name = 'my_queue'
 
           Que.mode = :async
           Que.worker_count = 2
@@ -120,7 +120,7 @@ describe "Managing the Worker pool" do
           job[:queue].should == ''
           job[:args].should == '[1]'
         ensure
-          ENV.delete('QUE_QUEUE')
+          Que.queue_name = nil
         end
       end
     end


### PR DESCRIPTION
I'm opening this as a PR so people have the chance to try it out and comment on it before it's merged into master. It replaces the current Rails-specific methods of working jobs (`rake que:work` and autostarting when the server runs) with a command-line interface. This will hopefully fix a lot of the persistent problems people have been having with workers running during migrations, asset compilations, in the console, etc.

From the changelog:

> A command-line program has been added that can be used to work jobs in a more flexible manner than the previous rake task. Run `que -h` for more information.
>
> The `rake que:work` rake task that was specific to Rails has been removed in favor of the CLI, and the various QUE_* environment variables no longer have any effect.
>
> The worker pool will no longer start automatically in the same process when running the rails server - this behavior was too prone to breakage. If you'd like to recreate the old behavior, you can manually set `Que.mode = :async` in your app whenever conditions are appropriate (classes have loaded, a database connection has been established, and the process will not be forking).

Currently, the `que` command must be invoked with the path of the application to load before jobs can be worked, and actually, any number of filenames can be provided and they'll be required in order. For people using Rails, you'll probably want to invoke the command like `que config/environment`. I considered trying to check whether the command was being called in the context of a Rails app by checking for the presence of the config/environment.rb, but this felt hacky to me. I understand that most people using Que are probably using it with Rails, though, so I suppose I could be talked into it.

Also be aware that the docs haven't been updated to reflect these changes, so take them with a grain of salt.

Feedback and experimentation (and even PRs to merge into this PR) welcome! And thanks to GoCardless for bringing up the idea a while ago, I took some inspiration from [Hutch](https://github.com/gocardless/hutch).