### PR TITLE
Clear active ActiveRecord connections between jobs.

### DIFF
--- a/lib/que/adapters/active_record.rb
+++ b/lib/que/adapters/active_record.rb
@@ -31,6 +31,7 @@ module Que
       private
 
       def checkout_activerecord_adapter(&block)
+        ::ActiveRecord::Base.clear_active_connections!
         ::ActiveRecord::Base.connection_pool.with_connection(&block)
       end
     end

--- a/lib/que/adapters/active_record.rb
+++ b/lib/que/adapters/active_record.rb
@@ -31,7 +31,6 @@ module Que
       private
 
       def checkout_activerecord_adapter(&block)
-        ::ActiveRecord::Base.clear_active_connections!
         ::ActiveRecord::Base.connection_pool.with_connection(&block)
       end
     end

--- a/lib/que/job.rb
+++ b/lib/que/job.rb
@@ -76,6 +76,8 @@ module Que
       end
 
       def work(queue = '')
+        ::ActiveRecord::Base.clear_active_connections!
+
         # Since we're taking session-level advisory locks, we have to hold the
         # same connection throughout the process of getting a job, working it,
         # deleting it, and removing the lock.


### PR DESCRIPTION
After having significant issues with long running database connections that only ever occurred on my worker processes, and not on my web processes, I investigated and found that Rails clears out active connections between each web request.

This PR implements the same connection clearing for Que. I'm sure the implementation is not ideal, and I'm happy to revise it with some advice. This has been running successfully in a production environment for a number of months, resolving all issues with long running database connections.