### PR TITLE
Support non-rails environment.

### DIFF
--- a/lib/que/rake_tasks.rb
+++ b/lib/que/rake_tasks.rb
@@ -1,3 +1,6 @@
+# stub environment task to support non-rails apps
+task :environment
+
 namespace :que do
   desc "Process Que's jobs using a worker pool"
   task :work => :environment do


### PR DESCRIPTION
For non-rails apps, rake tasks don't work since they require the ```environment``` task. This stubs the ```environment``` which should support both rails and non-rails apps then.

Based on https://github.com/QueueClassic/queue_classic/issues/62