### PR TITLE
Allow environment variables for configuration in bin/que

### DIFF
--- a/bin/que
+++ b/bin/que
@@ -59,7 +59,7 @@ end
 Que.logger ||= Logger.new(STDOUT)
 
 begin
-  if log_level = options.log_level
+  if log_level = (options.log_level || ENV['QUE_LOG_LEVEL'])
     Que.logger.level = Logger.const_get(log_level.upcase)
   end
 rescue NameError
@@ -67,9 +67,9 @@ rescue NameError
   exit 1
 end
 
-Que.queue_name    = options.queue_name    || Que.queue_name    || nil
-Que.worker_count  = options.worker_count  || Que.worker_count  || 4
-Que.wake_interval = options.wake_interval || Que.wake_interval || 0.1
+Que.queue_name    = options.queue_name     || ENV['QUE_QUEUE']         || Que.queue_name    || nil
+Que.worker_count  = (options.worker_count  || ENV['QUE_WORKER_COUNT']  || Que.worker_count  || 4).to_i
+Que.wake_interval = (options.wake_interval || ENV['QUE_WAKE_INTERVAL'] || Que.wake_interval || 0.1).to_f
 Que.mode          = :async
 
 stop = false


### PR DESCRIPTION
This PR allows `QUE_QUE`, `QUE_WORKER_COUNT`, `QUE_WAKE_INTERVAL` and `QUE_LOG_LEVEL` to be used. Precedence order is command line options, environment variables, `Que.[var]`, then the specified defaults.

We were lucky and had the same `DB_POOL` to the default worker count when we transitioned to `bin/que`.
