### PR TITLE
[Proposal] Add retry limit global configuration

### DIFF
--- a/docs/advanced_setup.md
+++ b/docs/advanced_setup.md
@@ -104,3 +104,17 @@ Que.mode = :sync
 Be sure to read the docs on [managing workers](https://github.com/chanks/que/blob/master/docs/managing_workers.md) for more information on using the worker pool.
 
 You'll also want to set up [logging](https://github.com/chanks/que/blob/master/docs/logging.md) and an [error handler](https://github.com/chanks/que/blob/master/docs/error_handling.md) to track errors raised by jobs.
+
+### Retry Limit
+
+Que will never delete a job, but it can be configured to stop trying to work a job. The default retry limit is 100, a limit that is very unlikely to be reached. If you wish to stop trying to work a job at a lower error count, you can configure Que like so:
+
+```ruby
+Que.retry_limit = 5
+```
+
+If, however, you've changed the `retry_interval` for your workers and want jobs to retry more times, you can of course raise this limit.
+
+```ruby
+Que.retry_limit = 100_000
+```

--- a/lib/que.rb
+++ b/lib/que.rb
@@ -49,7 +49,7 @@ module Que
 
   class << self
     attr_accessor :error_handler
-    attr_writer :logger, :adapter, :log_formatter, :disable_prepared_statements, :json_converter
+    attr_writer :logger, :adapter, :log_formatter, :disable_prepared_statements, :json_converter, :retry_limit
 
     def connection=(connection)
       self.adapter =
@@ -138,6 +138,18 @@ module Que
       else
         camel_cased_word.split('::').inject(Object, &:const_get)
       end
+    end
+
+    # Configure Que to stop trying to work a job
+    # after error_count surpasses this limit
+    # 
+    # This limit should never be reached
+    # 
+    # At the default retry_interval
+    # 100 retries would take over 3 years
+    # 
+    def retry_limit
+      @retry_limit ||= 100
     end
 
     # A helper method to manage transactions, used mainly by the migration

--- a/lib/que/job.rb
+++ b/lib/que/job.rb
@@ -84,7 +84,7 @@ module Que
         return_value =
           Que.adapter.checkout do
             begin
-              if job = Que.execute(:lock_job, [queue]).first
+              if job = Que.execute(:lock_job, [queue,  Que.retry_limit]).first
                 # Edge case: It's possible for the lock_job query to have
                 # grabbed a job that's already been worked, if it took its MVCC
                 # snapshot while the job was processing, but didn't attempt the

--- a/lib/que/sql.rb
+++ b/lib/que/sql.rb
@@ -50,6 +50,7 @@ module Que
           FROM que_jobs AS j
           WHERE queue = $1::text
           AND run_at <= now()
+          AND error_count <= $2::integer
           ORDER BY priority, run_at, job_id
           LIMIT 1
         ) AS t1
@@ -61,6 +62,7 @@ module Que
               FROM que_jobs AS j
               WHERE queue = $1::text
               AND run_at <= now()
+              AND error_count <= $2::integer
               AND (priority, run_at, job_id) > (jobs.priority, jobs.run_at, jobs.job_id)
               ORDER BY priority, run_at, job_id
               LIMIT 1

--- a/spec/unit/work_spec.rb
+++ b/spec/unit/work_spec.rb
@@ -403,5 +403,16 @@ describe Que::Job, '.work' do
       job[:error_count].should be 1
       job[:run_at].should be_within(3).of Time.now + 4
     end
+
+    it "should not work a job when error count exceeds retry limit" do
+      ErrorJob.enqueue
+
+      # Set the job error count to exceed the retry limit
+      DB[:que_jobs].update :error_count => (Que.retry_limit + 1),
+                           :run_at => Time.now - 60
+
+      result = Que::Job.work
+      result[:event].should == :job_unavailable
+    end
   end
 end


### PR DESCRIPTION
* Que.retry_limit, with default to 100
* Lock job query uses retry_limit against error_count
* Update docs
