### PR TITLE
Docs index via README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,33 @@
+Docs Index
+==============
+
+- [Advanced Setup](docs/advanced_setup.md)
+  - Using ActiveRecord Without Rails
+  - Forking Servers
+  - Managing the Jobs Table
+  - Other Setup
+- [Customizing Que](docs/customizing_que.md)
+  - Recurring Jobs
+  - DelayedJob-style Jobs
+  - QueueClassic-style Jobs
+  - Retaining Finished Jobs
+  - Not Retrying Certain Failed Jobs
+- [Error Handling](docs/error_handling.md)
+- [Inspecting the Queue](docs/inspecting_the_queue.md)
+  - Job Stats
+  - Worker States
+  - Custom Queries
+- [Logging](docs/logging.md)
+- [Managing Workers](docs/managing_workers.md)
+  - Working Jobs Via Executable
+  - Thread-Unsafe Application Code
+  - The Wake Interval
+  - Manually Waking Workers
+  - Connection Pool Size
+- [Migrating](docs/migrating.md)
+- [Multiple Queues](docs/multiple_queues.md)
+- [Shutting Down Safely](docs/shutting_down_safely.md)
+- [Using Plain Postgres Connections](docs/using_plain_connections.md)
+- [Using Sequel](docs/using_sequel.md)
+- [Writing Reliable Jobs](docs/writing_reliable_jobs.md)
+  - Timeouts


### PR DESCRIPTION
I'm looking at using Que in a web app I'm working on, but I see this project doesn't have a wiki and there's no index for the docs. This makes it a bit difficult for me to find what I'm looking for, so I started a basic index. It's a list of links to each doc with a sublist of with any subheadings for that doc.

I'd recommend adding short descriptions (a sentence or two perhaps) to the index to make it a bit clearer as to what is covered in each topic.