### PR TITLE
Update docs index to use anchor links

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,33 +1,33 @@
 Docs Index
 ==============
 
-- [Advanced Setup](advanced_setup.md)
-  - Using ActiveRecord Without Rails
-  - Forking Servers
-  - Managing the Jobs Table
-  - Other Setup
-- [Customizing Que](customizing_que.md)
-  - Recurring Jobs
-  - DelayedJob-style Jobs
-  - QueueClassic-style Jobs
-  - Retaining Finished Jobs
-  - Not Retrying Certain Failed Jobs
-- [Error Handling](error_handling.md)
-- [Inspecting the Queue](inspecting_the_queue.md)
-  - Job Stats
-  - Worker States
-  - Custom Queries
-- [Logging](logging.md)
-- [Managing Workers](managing_workers.md)
-  - Working Jobs Via Executable
-  - Thread-Unsafe Application Code
-  - The Wake Interval
-  - Manually Waking Workers
-  - Connection Pool Size
-- [Migrating](migrating.md)
-- [Multiple Queues](multiple_queues.md)
-- [Shutting Down Safely](shutting_down_safely.md)
-- [Using Plain Postgres Connections](using_plain_connections.md)
-- [Using Sequel](using_sequel.md)
-- [Writing Reliable Jobs](writing_reliable_jobs.md)
-  - Timeouts
+- [Advanced Setup](advanced_setup.md#advanced-setup)
+  - [Using ActiveRecord Without Rails](advanced_setup.md#using-activerecord-without-rails)
+  - [Forking Servers](advanced_setup.md#forking-servers)
+  - [Managing the Jobs Table](advanced_setup.md#managing-the-jobs-table)
+  - [Other Setup](advanced_setup.md#other-setup)
+- [Customizing Que](customizing_que.md#customizing-que)
+  - [Recurring Jobs](customizing_que.md#recurring-jobs)
+  - [DelayedJob-style Jobs](customizing_que.md#delayedjob-style-jobs)
+  - [QueueClassic-style Jobs](customizing_que.md#queueclassic-style-jobs)
+  - [Retaining Finished Jobs](customizing_que.md#retaining-finished-jobs)
+  - [Not Retrying Certain Failed Jobs](customizing_que.md#not-retrying-certain-failed-jobs)
+- [Error Handling](error_handling.md#error-handling)
+- [Inspecting the Queue](inspecting_the_queue.md#inspecting-the-queue)
+  - [Job Stats](inspecting_the_queue.md#job-stats)
+  - [Worker States](inspecting_the_queue.md#worker-states)
+  - [Custom Queries](inspecting_the_queue.md#custom-queries)
+- [Logging](logging.md#logging)
+- [Managing Workers](managing_workers.md#managing-workers)
+  - [Working Jobs Via Executable(managing_workers.md#working-jobs-via-executable)
+  - [Thread-Unsafe Application Code(managing_workers.md#thread-unsafe-application-code)
+  - [The Wake Interval(managing_workers.md#the-wake-interval)
+  - [Manually Waking Workers(managing_workers.md#manually-waking-workers)
+  - [Connection Pool Size(managing_workers.md#connection-pool-size)
+- [Migrating](migrating.md#migrating)
+- [Multiple Queues](multiple_queues.md#multiple-queues)
+- [Shutting Down Safely](shutting_down_safely.md#shutting-down-safely)
+- [Using Plain Postgres Connections](using_plain_connections.md#using-plain-postgres-connections)
+- [Using Sequel](using_sequel.md#using-sequel)
+- [Writing Reliable Jobs](writing_reliable_jobs.md#writing-reliable-jobs)
+  - [Timeouts](writing_reliable_jobs.md#timeouts)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,5 @@
 Docs Index
-==============
+===============
 
 - [Advanced Setup](advanced_setup.md#advanced-setup)
   - [Using ActiveRecord Without Rails](advanced_setup.md#using-activerecord-without-rails)


### PR DESCRIPTION
I've updated the index to use anchor links so that the links go directly to the (sub)heading rather than just the top of the page.