### PR TITLE
Handle nested transactions in Rails 5

### DIFF
--- a/lib/que/adapters/active_record.rb
+++ b/lib/que/adapters/active_record.rb
@@ -46,6 +46,14 @@ module Que
         def before_committed!(*)
           # no-op
         end
+
+        def add_to_transaction
+          # no-op.
+          #
+          # This is called when we're in a nested transaction. Ideally we would
+          # `wake!` when the outer transaction gets committed, but that would be
+          # a bigger refactor!
+        end
       end
 
       private


### PR DESCRIPTION
Currently, the setup added to the spec in the PR causes a `NoMethodError: 'undefined method add_to_transaction'` when running against ActiveRecord 5.

This PR adds a naive fix, which makes Que compatible with ActiveRecord 5. It's not the best possible solution (which is described in a comment), but it removes the blocker for anyone moving to Rails 5.