### PR TITLE
Make Que's ActiveRecord adapter compatible with Rails 5.0

### DIFF
--- a/lib/que/adapters/active_record.rb
+++ b/lib/que/adapters/active_record.rb
@@ -63,7 +63,7 @@ module Que
 
       def checkout_activerecord_adapter(&block)
         Thread.current[:que_activerecord_connection] ||= ::ActiveRecord::Base.connection
-        block.call(Thread.current[:que_ar_conn])
+        block.call(Thread.current[:que_activerecord_connection])
       end
     end
   end


### PR DESCRIPTION
This is about the most surgical fix I could think of which would allow reentrant on the checkout function without a massive refactor of the way that Que's SQL execution works.