### PR TITLE
explicitly require ActiveRecord::Base

### DIFF
--- a/lib/que/adapters/active_record.rb
+++ b/lib/que/adapters/active_record.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'active_record/base'
+
 module Que
   module Adapters
     class ActiveRecord < Base


### PR DESCRIPTION
Otherwise it is possible to get exception when running tests: `test/test_helper.rb:23:in `<class:TestCase>': undefined method `fixtures' for ActiveSupport::TestCase:Class (NoMethodError)`

This adapter uses ActiveRecord::Base so it is only fair to require it.