### PR TITLE
Add reference to que-scheduler

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ To determine what happens when a job is queued, you can set Que's mode. There ar
 
   * [que-web](https://github.com/statianzo/que-web) is a Sinatra-based UI for inspecting your job queue.
   * [que-testing](https://github.com/statianzo/que-testing) allows making assertions on enqueued jobs.
+  * [que-scheduler](https://github.com/hlascelles/que-scheduler) is a cron scheduler for Que jobs that runs on Que itself.
   * [que-go](https://github.com/bgentry/que-go) is a port of Que for the Go programming language. It uses the same table structure, so that you can use the same job queue from Ruby and Go applications.
   * [wisper-que](https://github.com/joevandyk/wisper-que) adds support for Que to [wisper](https://github.com/krisleech/wisper).
 

--- a/docs/customizing_que.md
+++ b/docs/customizing_que.md
@@ -52,6 +52,8 @@ Note also the use of the triple-dot range, which results in a query like `SELECT
 
 Finally, by passing both the start and end times for the period to be processed, and only using the interval to calculate the period for the following job, we make it easy to change the interval at which the job runs, without the risk of missing or double-processing any users.
 
+For more declarative scheduling, the [que-scheduler](https://github.com/hlascelles/que-scheduler) gem can be used to enqueue jobs defined with a cron based configuration. que-scheduler itself is a Que job, so it comes with the same ACID guarantees and DB restore semantics that Que benefits from, and can perform missed job executions after a full system downtime.
+
 ### DelayedJob-style Jobs
 
 DelayedJob offers a simple API for delaying methods to objects:


### PR DESCRIPTION
This adds a reference to [que-scheduler](https://github.com/hlascelles/que-scheduler), and a summary in the recurring jobs section.