### PR TITLE
Fix ActiveRecord migration error

### DIFF
--- a/lib/generators/que/templates/add_que.rb
+++ b/lib/generators/que/templates/add_que.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddQue < ActiveRecord::Migration
+class AddQue < ActiveRecord::Migration[4.2]
   def self.up
     # The current version as of this migration's creation.
     Que.migrate! :version => 3


### PR DESCRIPTION
>Directly inheriting from ActiveRecord::Migration is not supported.
Please specify the Rails release the migration was written for:

>  class AddQue < ActiveRecord::Migration[4.2]

Fixes #194