### PR TITLE
[CI] Test against Ruby 2.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ cache: bundler
 rvm:
   - 2.2
   - 2.3
-  - 2.4.0
+  - 2.4
+  - 2.5
   - ruby-head
   # The Rubinii aren't installing properly on Travis :/
   # - rbx-2


### PR DESCRIPTION
All tested version are currently failing  for `Gemfile.old`.
To treat in another PR.