### PR TITLE
Adds instructions for Sequel migrator

### DIFF
--- a/docs/using_sequel.md
+++ b/docs/using_sequel.md
@@ -7,6 +7,22 @@ DB = Sequel.connect(ENV['DATABASE_URL'])
 Que.connection = DB
 ```
 
+If you are using Sequels' migrator, you can use the following migration to create the required tables:
+
+```ruby
+require 'que'
+Sequel.migration do
+  up do
+    Que.connection = self
+    Que.migrate! :version => 3
+  end
+  down do
+    Que.connection = self
+    Que.migrate! :version => 0
+  end
+end
+```
+
 Then you can safely use the same database object to transactionally protect your jobs:
 
 ```ruby


### PR DESCRIPTION
This minor documentation change explains how to create a Sequel migration for Que. It includes both the up and down methods so it can be safely rolled back. The current documentation includes a generator for ActiveRecord but there's no information of the equivalent when using Sequel.