### PR TITLE
Handle errors with blank message when setting last_error.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Unreleased
+
+*   Fix handling of last_error message for errors with blank message.
+
 ### 0.14.2 (2018-01-05)
 
 *   Deprecate the Que.disable_prepared_statements= accessors.

--- a/spec/unit/work_spec.rb
+++ b/spec/unit/work_spec.rb
@@ -406,14 +406,12 @@ describe Que::Job, '.work' do
 
     it "should use the class name of the exception if its message is blank when setting last_error" do
       class BlankExceptionMessageJob < Que::Job
-        class << self
-          attr_accessor :last_error
+        def self.error
+          @error ||= RuntimeError.new("")
         end
 
         def run
-          error = RuntimeError.new("")
-          self.class.last_error = error
-          raise error
+          raise self.class.error
         end
       end
 
@@ -423,7 +421,7 @@ describe Que::Job, '.work' do
       job = DB[:que_jobs].first
       job[:error_count].should be 1
       last_error_lines = job[:last_error].split("\n")
-      last_error_lines.should == %w[RuntimeError] + BlankExceptionMessageJob.last_error.backtrace
+      last_error_lines.should == %w[RuntimeError] + BlankExceptionMessageJob.error.backtrace
     end
 
     context "in a job class that has a custom error handler" do


### PR DESCRIPTION
If an error is raised with a blank message, as (for example) sometimes
`OpenSSL::Cipher::CipherError` can be, the `last_error` that is saved
to the DB for that job has a confusing first blank line. For older
versions of Que (before 3feebc56738a3b114472386a4c68e3ac1b541a4c) with
no stacktrace, all you get is an empty string.
