### PR TITLE
disable run_synchronously in Rails tests

### DIFF
--- a/lib/que/rails/railtie.rb
+++ b/lib/que/rails/railtie.rb
@@ -5,7 +5,7 @@ module Que
     class Railtie < ::Rails::Railtie
       config.que = Que
 
-      Que.run_asynchronously = true if ::Rails.env.test?
+      Que.run_synchronously = false if ::Rails.env.test?
 
       Que.logger     = proc { ::Rails.logger }
       Que.connection = ::ActiveRecord if defined? ::ActiveRecord


### PR DESCRIPTION
This is my attempt to fix #214. Hoping that I correctly understood the intent of this bit of code.

Fixes #214.