### PR TITLE
Fix typecast when value is already type of Time.

### DIFF
--- a/lib/que/connection.rb
+++ b/lib/que/connection.rb
@@ -152,7 +152,12 @@ module Que
       },
 
       # Timestamp with time zone
-      1184 => Time.method(:parse),
+      1184 => -> (value) {
+        case value
+        when String then Time.parse(value)
+        else value
+        end
+      }
     }
 
     # JSON, JSONB


### PR DESCRIPTION
I'm running que `1.0.0.beta3` with rails `6.0.0.beta3` and ran into issues with typecasting. Seems like the value of `run_at` is already of type `Time` so trying to parse it again raises an error. 
This PR tries to fix the described issue 🙂