### PR TITLE
fix parser of time in convert_result method

### DIFF
--- a/lib/que/connection.rb
+++ b/lib/que/connection.rb
@@ -152,7 +152,10 @@ module Que
       },
 
       # Timestamp with time zone
-      1184 => Time.method(:parse),
+      1184 => -> (value) {
+        return value if value.is_a? Time
+        Time.parse value if value.is_a? String
+      }
     }
 
     # JSON, JSONB


### PR DESCRIPTION
There is trouble on macOS, Rails 6 RC1 with (PostgreSQL) 11.3
Timestamp "run_at" is already returned as Time, not as String which is currently expected.

- changed direct method call to lambda with guard and original method call
- handled situation when value is already of a Time class by adding guard

